### PR TITLE
suppress ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,12 @@
             <version>2.2</version>
         </dependency>
 
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>annotations</artifactId>
+            <version>3.0.1</version>
+        </dependency>
+
 
     </dependencies>
     <build>

--- a/src/main/java/sdk/mssearch/javasdk/ApplicationContextHolder.java
+++ b/src/main/java/sdk/mssearch/javasdk/ApplicationContextHolder.java
@@ -1,5 +1,6 @@
 package sdk.mssearch.javasdk;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.springframework.beans.BeansException;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
@@ -8,6 +9,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @Order(Integer.MIN_VALUE)
+@SuppressFBWarnings("ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD")
 public class ApplicationContextHolder implements ApplicationContextAware {
 
     private static ApplicationContext context;


### PR DESCRIPTION
ApplicationContextHolder 是透過 spring 註冊 context後，注入到 ApplicationContextHolder 是特別設計機制 因此略過，正常都會透過 DI 方式取得 bean 